### PR TITLE
Fix Facebook Share bug 

### DIFF
--- a/_includes/floating-header.html
+++ b/_includes/floating-header.html
@@ -15,7 +15,7 @@
             onclick="window.open(this.href, 'share-twitter', 'width=550,height=235');return false;">
             {% include twitter.html %}
         </a>
-        <a class="floating-header-share-fb" href="https://www.facebook.com/sharer/sharer.php?u={{ site.production_url }}{{ page.url | remove_first: '/' }}"
+        <a class="floating-header-share-fb" href="https://www.facebook.com/sharer/sharer.php?u={{ site.production_url }}{{ page.url | remove_first: '/' | remove_last: '/' }}"
             onclick="window.open(this.href, 'share-facebook','width=580,height=296');return false;">
             {% include facebook.html %}
         </a>


### PR DESCRIPTION
Strip trailing slash since it causes 404 error